### PR TITLE
feat(service-settings/cors) - implement CORS rule manipulation

### DIFF
--- a/app/components/ax-collection.js
+++ b/app/components/ax-collection.js
@@ -3,18 +3,6 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   content: null,
 
-  selectedValue: Ember.computed.alias('value'),
-
-  allowedOriginsString: function () {
-    var origins = '';
-
-    this.get('selectedValue.AllowedOrigins').each(host => {
-      origins += host;
-    });
-
-    return origins;
-  }.property('AllowedOrigins'),
-
   didInitAttrs() {
     this._super(...arguments);
     var content = this.get('content');
@@ -25,14 +13,10 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    change() {
-      const selectedEl = this.$('select')[0];
-      const selectedIndex = selectedEl.selectedIndex;
-      const content = this.get('content');
-      const selectedValue = content[selectedIndex];
-
-      this.set('selectedValue', selectedValue);
-      this.set('value', selectedValue);
+    select: function (item) {
+      console.log(item);
+      this.set('selectedValue', item);
+      this.sendAction();
     }
   }
 });

--- a/app/controllers/welcome.js
+++ b/app/controllers/welcome.js
@@ -156,8 +156,8 @@ export default Ember.Controller.extend({
             }
 
             this.store.findAll('account').then(function (accounts) {
-                var i;
-                var account;
+                var i,
+                account;
 
                 if (accounts && accounts.content && accounts.content.length > 0) {
                     for (i = 0; i < accounts.content.length; i = i + 1) {
@@ -171,8 +171,9 @@ export default Ember.Controller.extend({
                     }
                 }
 
-                self.store.find('serviceSettings', 'settings')
+                self.store.find('serviceSettings', activeAccountId)
                 .then(settings => {
+                    console.log('break here');
                     self.set('application.serviceSettings', settings);
                     self.transitionToRoute('explorer');
                 })

--- a/app/models/cors-rule.js
+++ b/app/models/cors-rule.js
@@ -2,4 +2,8 @@ import DS from 'ember-data';
 
 export default DS.ModelFragment.extend({
   // TODO: Add attributes
+  AllowedHeaders: DS.hasManyFragments('stringValue'),
+  AllowedMethods: DS.hasManyFragments('stringValue'),
+  AllowedOrigins: DS.hasManyFragments('stringValue'),
+  MaxAgeInSeconds: DS.attr('number')
 });

--- a/app/models/service-settings.js
+++ b/app/models/service-settings.js
@@ -3,5 +3,6 @@ export default DS.Model.extend({
 
   MinuteMetrics: DS.hasOneFragment('metrics'),
   HourMetrics: DS.hasOneFragment('metrics'),
-  Logging: DS.hasOneFragment('logging')
+  Logging: DS.hasOneFragment('logging'),
+  Cors: DS.hasOneFragment('cors')
 });

--- a/app/models/string-value.js
+++ b/app/models/string-value.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
 
 export default DS.ModelFragment.extend({
-  CorsRule: DS.hasManyFragments('corsRule')
+  Value: DS.attr('string')
 });

--- a/app/routes/explorer.js
+++ b/app/routes/explorer.js
@@ -6,6 +6,7 @@ import config from '../config/environment';
  * Ember Explorer Route
  */
 export default Ember.Route.extend({
+    application: Ember.inject.service(),
     /**
      * Get all containers for the current account, set them as model
      */
@@ -111,6 +112,7 @@ export default Ember.Route.extend({
         },
 
         goHome: function () {
+            this.set('application.serviceSettings', {});
             this.transitionTo('welcome');
         }
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -54,11 +54,13 @@ a:not(.btn-flat, .btn) {
 .modal {
     nav.props {
         background-color: $secondary-color;
-        
+
         a.brand-logo {
             font-size: 20px
         }
     }
+
+    max-height: 80%;
 }
 
 .select-dropdown {
@@ -69,7 +71,7 @@ a:not(.btn-flat, .btn) {
 }
 
 // Fix Materialize Select Cut-off issue
-div.card-content, div.card, 
+div.card-content, div.card,
 div.card .liquid-container:not(.liquid-animating),
 div.card .liquid-child:not(.liquid-animating) {
     overflow: visible!important;

--- a/app/styles/application-settings.scss
+++ b/app/styles/application-settings.scss
@@ -3,12 +3,31 @@
       width: 180px
     }
 
+    height: 475px;
+
     .select-wrapper {
       width: 150px
     }
 
     input {
       width: 130px
+    }
+
+    div.collectionContainer {
+        height: 180px;
+        overflow: scroll;
+        padding-bottom: 20px;
+    }
+
+    div.corsInput {
+        height:15px;
+        input {
+          width: 400px;
+        }
+    }
+
+    .delete {
+      background-color: $warning-color;
     }
 }
 

--- a/app/styles/color-overrides.scss
+++ b/app/styles/color-overrides.scss
@@ -7,3 +7,4 @@ $secondary-color: #8AC340;
 $success-color: color("green", "base");
 $error-color: color("red", "base");
 $link-color: color("light-blue", "darken-1");
+$warning-color: #FF4D4D;

--- a/app/templates/components/ax-application-settings.hbs
+++ b/app/templates/components/ax-application-settings.hbs
@@ -1,6 +1,6 @@
 <div id="modal-app-settings" class="modal" >
-    {{ax-modal-navbar modalTitle="Settings" tab1="Metrics" tab2="Logging" tab3="About" target=this}}
-    <div class="modal-content properties-dialog settings-dialog">
+    {{ax-modal-navbar modalTitle="Settings" tab1="Metrics" tab2="Logging" tab3="CORS" tab4="About" target=this}}
+    <div class="modal-content settings-dialog properties-dialog">
         {{#if showMetrics}}
           <p>Use the Settings below to enable <a {{action "open" "https://msdn.microsoft.com/en-us/library/azure/hh343270.aspx" target=applicationController}} href="">Storage Analytics</a> on your storage account</p>
           <table class="striped properties">
@@ -15,7 +15,7 @@
                   </td>
                   <td>
                     <label class="active" for="minute-metrics-enabled">Enabled</label>
-                    {{ax-select nanme="minute-metrics-enabled" content=onOffContent value=settings.MinuteMetrics.Enabled}}
+                    {{ax-select name="minute-metrics-enabled" content=onOffContent value=settings.MinuteMetrics.Enabled}}
                   </td>
               </tr>
               <tr>
@@ -76,7 +76,36 @@
               </tr>
           </table>
         {{else if showCORS}}
-{{!--           {{ax-collection value=settings.Cors.Cors}} --}}
+          {{ax-collection action="selectRule" content=settings.Cors.CorsRule selectedValue=currentRule}}
+          <div class="row">
+            <a {{action "newCorsRule"}} {{bind-attr disabed=loading}} class="waves-effect waves-light btn"><i class="mdi-action-launch left"></i>New Rule</a>
+            <a {{action "deleteCorsRule"}} {{bind-attr disabed=loading}} class="waves-effect waves-light btn delete"><i class="mdi-action-delete left"></i>Delete Rule</a>
+          </div>
+          {{#if showNewRule}}
+            Enter a New Rule:
+          {{/if}}
+          {{#if showEditRule}}
+            Edit Rule:
+          {{/if}}
+          <div class="row">
+              <div class="row corsInput">
+                {{input placeholder="http://domain1.com;http://domain2.com" value=selectedCorsOriginString id="allowed_origins" type="text" class="validate"}}
+                <label for="allowed_origins">Allowed Origins</label>
+              </div>
+              <div class="row corsInput">
+                {{input placeholder="GET;POST" value=selectedCorsMethodString id="allowed_methods" type="text" class="validate"}}
+                <label for="allowed_methods">Allowed Methods</label>
+              </div>
+              <div class="row corsInput">
+                {{input placeholder="x-ms-header1;x-ms-header2" value=selectedCorsHeaderString id="allowed_headers" type="text" class="validate"}}
+                <label for="allowed_headers">Allowed Headers</label>
+              </div>
+              <div class="row corsInput">
+              {{input placeholder="1000" type="text" value=selectedMaxAgeSeconds id="max_age"}}
+              <label for="max_age">Max Age (seconds)</label>
+              </div>
+            </div>
+
         {{else if showAbout}}
           <p><strong>Azure Storage Explorer</strong></p>
           <p><strong>version: {{versionNumber}}</strong></p>

--- a/app/templates/components/ax-collection.hbs
+++ b/app/templates/components/ax-collection.hbs
@@ -1,10 +1,12 @@
-{{!-- <div class="collection" {{action 'change' on='change'}}>
+<div class="collection collectionContainer" {{action 'change' on='change'}}>
   {{#each content key="@index" as |item|}}
-    <option value="{{item}}" active={{is-equal item selectedValue}}>
-      {{allowedOriginsString}}
-    </option>
+    <a {{action 'select' item}} class="collection-item {{if (is-equal item selectedValue) 'active'}}" >
+      {{#each item.AllowedOrigins as |origin|}}
+        {{origin.Value}};
+      {{/each}}
+    </a>
   {{/each}}
   {{#if label}}
     <label>{{label}}</label>
   {{/if}}
-</div> --}}
+</div>

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -80,31 +80,68 @@ export default function startApp(attrs, assert, noNodeServices) {
         ]
     };
     var fakeSettings = {
-        HourMetrics: {
-            Enabled: false,
-            IncludeAPIs: false,
-            Days: 0,
-            RetentionPolicy: {
-              Enabled: false
-            }
-        },
-        MinuteMetrics: {
-            Enabled: false,
-            IncludeAPIs: false,
-            Days: 0,
-            RetentionPolicy: {
-              Enabled: false
-            }
-        },
-        Logging: {
-            Enabled: false,
-            Delete: false,
-            Read: false,
-            Write: false,
-            RetentionPolicy: {
-              Enabled: false
-            }
-        }
+      HourMetrics: {
+          Enabled: false,
+          IncludeAPIs: false,
+          Days: 0,
+          RetentionPolicy: {
+            Enabled: false
+          }
+      },
+      MinuteMetrics: {
+          Enabled: false,
+          IncludeAPIs: false,
+          Days: 0,
+          RetentionPolicy: {
+            Enabled: false
+          }
+      },
+      Logging: {
+          Enabled: false,
+          Delete: false,
+          Read: false,
+          Write: false,
+          RetentionPolicy: {
+            Enabled: false
+          }
+      },
+      Cors: {
+        CorsRule: [
+          {
+            AllowedHeaders: [
+              'x-ms-fake-header1',
+              'x-ms-fake-header2'
+            ],
+            AllowedMethods: [
+              'GET',
+              'PUT'
+            ],
+            AllowedOrigins: [
+              'http://testdomain.com',
+              'http://testdomain2.com'
+            ],
+            MaxAgeInSeconds: 1000,
+            ExposedHeaders: [
+            ]
+          },
+          {
+            AllowedHeaders: [
+              'x-ms-fake-header'
+            ],
+            AllowedMethods: [
+              'GET',
+              'PUT'
+            ],
+            AllowedOrigins: [
+              'http://testdomain3.com',
+              'http://testdomain4.com'
+            ],
+            MaxAgeInSeconds: 1000,
+            ExposedHeaders: [
+            ]
+          }
+        ]
+      }
     };
     nodeServices.set('azureStorage', {
         BlobService: {

--- a/tests/unit/components/ax-application-settings-test.js
+++ b/tests/unit/components/ax-application-settings-test.js
@@ -12,7 +12,9 @@ var globals = {
 };
 
 moduleForComponent('ax-application-settings', {
-    needs: ['util:filesize', 'model:serviceSettings', 'service:nodeServices', 'service:application', 'service:notifications'],
+    needs: ['util:filesize', 'model:serviceSettings', 'model:stringValue',
+    'service:nodeServices', 'service:application', 'service:notifications',
+    'model:corsRule'],
     teardown: function () {
         Ember.run(globals.App, globals.App.destroy);
         window.localStorage.clear();
@@ -74,8 +76,9 @@ test('it updates logging metrics w/ notification', function (assert) {
             cmpt.set('application.serviceSettings.Logging.Read', true);
             cmpt.set('application.serviceSettings.Logging.Write', true);
             assert.equal(cmpt.get('settings.hasDirtyAttributes'), true);
+            // Here we override the notification controllers function
+            // in order to tell if this component is sucessfully notifying the UI
             cmpt.set('notifications.addPromiseNotification', function (promise) {
-              Ember.Logger.debug('called!!!');
               promise.then(() => {
                 assert.equal(cmpt.get('settings.hasDirtyAttributes'), false);
                 assert.equal(cmpt.get('application.serviceSettings.Logging.Enabled'), true);
@@ -92,3 +95,216 @@ test('it updates logging metrics w/ notification', function (assert) {
     });
 });
 
+test('it correctly surfaces selected Cors rule info for rendering', function (assert) {
+    combinedStart(assert, globals);
+    assert.expect(6);
+    Ember.run(() => {
+        let cmpt = this.subject();
+
+        globals.store.find('serviceSettings', 'settings')
+        .then(settings => {
+            cmpt.set('application.serviceSettings', settings);
+            cmpt.set('currentRule', settings.get('Cors.CorsRule.firstObject'));
+            cmpt.send('selectRule');
+            assert.equal(cmpt.get('selectedCorsOriginString'), 'http://testdomain.com;http://testdomain2.com;');
+            assert.equal(cmpt.get('selectedCorsHeaderString'), 'x-ms-fake-header1;x-ms-fake-header2;');
+            assert.equal(cmpt.get('selectedCorsMethodString'), 'GET;PUT;');
+
+            cmpt.set('currentRule', settings.get('Cors.CorsRule.lastObject'));
+            cmpt.send('selectRule');
+            assert.equal(cmpt.get('selectedCorsOriginString'), 'http://testdomain3.com;http://testdomain4.com;');
+            assert.equal(cmpt.get('selectedCorsHeaderString'), 'x-ms-fake-header;');
+            assert.equal(cmpt.get('selectedCorsMethodString'), 'GET;PUT;');
+        });
+
+    });
+});
+
+test('it clears rule data when sent newCorsRule', function (assert) {
+    combinedStart(assert, globals);
+    assert.expect(6);
+    Ember.run(() => {
+        let cmpt = this.subject();
+
+        globals.store.find('serviceSettings', 'settings')
+        .then(settings => {
+            cmpt.set('application.serviceSettings', settings);
+            cmpt.set('currentRule', settings.get('Cors.CorsRule.firstObject'));
+            cmpt.send('selectRule');
+            assert.equal(cmpt.get('selectedCorsOriginString'), 'http://testdomain.com;http://testdomain2.com;');
+            assert.equal(cmpt.get('selectedCorsHeaderString'), 'x-ms-fake-header1;x-ms-fake-header2;');
+            assert.equal(cmpt.get('selectedCorsMethodString'), 'GET;PUT;');
+            cmpt.send('newCorsRule');
+            assert.equal(cmpt.get('selectedCorsOriginString'), '');
+            assert.equal(cmpt.get('selectedCorsHeaderString'), '');
+            assert.equal(cmpt.get('selectedCorsMethodString'), '');
+        });
+
+    });
+});
+
+test('it correctly deletes a rule', function (assert) {
+    combinedStart(assert, globals);
+    assert.expect(10);
+    Ember.run(() => {
+        let cmpt = this.subject();
+
+        globals.store.find('serviceSettings', 'settings')
+        .then(settings => {
+            cmpt.set('application.serviceSettings', settings);
+
+            // confirm we have 2 rules provided by mock api
+            assert.equal(settings.get('Cors.CorsRule.length'), 2);
+
+            // sim 'click' on a rule
+            cmpt.send('selectRule', settings.get('Cors.CorsRule.lastObject'));
+
+            // sim 'click' on delete rule button
+            cmpt.send('deleteCorsRule');
+            // confirm model has unsaved changes
+            assert.equal(cmpt.get('settings.hasDirtyAttributes'), true);
+
+            // confirm notification, and check component state after resolution
+            cmpt.set('notifications.addPromiseNotification', function (promise) {
+              promise.then(() => {
+                assert.equal(cmpt.get('settings.hasDirtyAttributes'), false);
+                assert.equal(settings.get('Cors.CorsRule.length'), 1);
+                cmpt.send('selectRule', settings.get('Cors.CorsRule.firstObject'));
+                // confirm we deleted the second, and not the first rule
+                assert.equal(cmpt.get('selectedCorsOriginString'), 'http://testdomain.com;http://testdomain2.com;');
+                assert.equal(cmpt.get('selectedCorsHeaderString'), 'x-ms-fake-header1;x-ms-fake-header2;');
+                assert.equal(cmpt.get('selectedCorsMethodString'), 'GET;PUT;');
+
+              });
+            });
+
+            cmpt.send('updateServiceSettings');
+        });
+
+    });
+});
+
+test('it correctly deletes all rules', function (assert) {
+    combinedStart(assert, globals);
+    assert.expect(7);
+    Ember.run(() => {
+        let cmpt = this.subject();
+
+        globals.store.find('serviceSettings', 'settings')
+        .then(settings => {
+            cmpt.set('application.serviceSettings', settings);
+
+            // confirm we have 2 rules provided by mock api
+            assert.equal(settings.get('Cors.CorsRule.length'), 2);
+
+            // sim 'click' on a rule
+            cmpt.send('selectRule', settings.get('Cors.CorsRule.lastObject'));
+            cmpt.send('deleteCorsRule');
+            // confirm model has unsaved changes
+            assert.equal(cmpt.get('settings.hasDirtyAttributes'), true);
+
+            // confirm notification, and check component state after resolution
+            cmpt.set('notifications.addPromiseNotification', function (promise) {
+              promise.then(() => {
+                assert.equal(cmpt.get('settings.hasDirtyAttributes'), false);
+                assert.equal(settings.get('Cors.CorsRule.length'), 0);
+              });
+            });
+
+            // delete all rules
+            settings.get('Cors.CorsRule').forEach( rule => {
+              cmpt.set('currentRule', rule);
+              cmpt.send('selectRule');
+              cmpt.send('deleteCorsRule');
+            });
+
+            cmpt.send('updateServiceSettings');
+        });
+
+    });
+});
+
+test('it adds a new rule', function (assert) {
+    combinedStart(assert, globals);
+    assert.expect(12);
+    Ember.run(() => {
+        let cmpt = this.subject();
+
+        globals.store.find('serviceSettings', 'settings')
+        .then(settings => {
+            cmpt.set('application.serviceSettings', settings);
+
+            // confirm we have 2 rules provided by mock api
+            assert.equal(settings.get('Cors.CorsRule.length'), 2);
+
+            cmpt.send('newCorsRule');
+
+            // sim input by user
+            cmpt.set('selectedCorsOriginString', 'http://testdomain5.com;http://testdomain6.com');
+            cmpt.set('selectedCorsHeaderString', 'x-ms-fake-header5');
+            cmpt.set('selectedCorsMethodString', 'PUT;POST');
+
+            // confirm notification, and check component state after resolution
+            cmpt.set('notifications.addPromiseNotification', function (promise) {
+              promise.then(() => {
+                assert.equal(cmpt.get('settings.hasDirtyAttributes'), false);
+                assert.equal(cmpt.get('settings.Cors.CorsRule.length'), 3);
+
+                // confirm the last rule is the one we added
+                cmpt.set('currentRule', cmpt.get('settings.Cors.CorsRule.lastObject'));
+                cmpt.send('selectRule');
+                assert.equal('http://testdomain5.com;http://testdomain6.com;', cmpt.get('selectedCorsOriginString'));
+                assert.equal('x-ms-fake-header5;', cmpt.get('selectedCorsHeaderString'));
+                assert.equal('PUT;POST;', cmpt.get('selectedCorsMethodString'));
+
+                // inspect model
+                assert.equal(cmpt.get('settings.Cors.CorsRule.lastObject.AllowedOrigins.length'), 2);
+                assert.equal(cmpt.get('settings.Cors.CorsRule.lastObject.AllowedMethods.length'), 2);
+                assert.equal(cmpt.get('settings.Cors.CorsRule.lastObject.AllowedHeaders.length'), 1);
+              });
+            });
+
+            cmpt.send('updateServiceSettings');
+
+
+        });
+
+    });
+});
+
+test('it modifies an existing rule', function (assert) {
+    combinedStart(assert, globals);
+    assert.expect(12);
+    Ember.run(() => {
+        let cmpt = this.subject();
+
+        globals.store.find('serviceSettings', 'settings')
+        .then(settings => {
+            cmpt.set('application.serviceSettings', settings);
+            cmpt.set('currentRule', settings.get('Cors.CorsRule.firstObject'));
+            cmpt.send('selectRule');
+            assert.equal(cmpt.get('selectedCorsOriginString'), 'http://testdomain.com;http://testdomain2.com;');
+            assert.equal(cmpt.get('selectedCorsHeaderString'), 'x-ms-fake-header1;x-ms-fake-header2;');
+            assert.equal(cmpt.get('selectedCorsMethodString'), 'GET;PUT;');
+
+            cmpt.set('selectedCorsOriginString', 'http://testdomain.com;http://addeddomain.com;http://testdomain2.com;');
+            cmpt.set('selectedCorsHeaderString', 'x-ms-fake-replaced;x-ms-fake-header2;');
+
+            cmpt.set('notifications.addPromiseNotification', function (promise) {
+              promise.then(() => {
+                assert.equal(cmpt.get('settings.hasDirtyAttributes'), false);
+                assert.equal(cmpt.get('settings.Cors.CorsRule.length'), 2);
+                assert.equal(cmpt.get('settings.Cors.CorsRule.firstObject.AllowedOrigins.length'), 3);
+                assert.equal(cmpt.get('selectedCorsOriginString'), 'http://testdomain.com;http://addeddomain.com;http://testdomain2.com;');
+                assert.equal(cmpt.get('selectedCorsHeaderString'), 'x-ms-fake-replaced;x-ms-fake-header2;');
+                assert.equal(cmpt.get('selectedCorsMethodString'), 'GET;PUT;');
+              });
+            });
+
+            cmpt.set('currentRule', settings.get('Cors.CorsRule.lastObject'));
+            cmpt.send('updateServiceSettings');
+
+        });
+
+    });
+});

--- a/tests/unit/components/ax-collection-test.js
+++ b/tests/unit/components/ax-collection-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('ax-collection', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/ax-select-test.js
+++ b/tests/unit/components/ax-select-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('ax-select', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
- Reusable collection component for using the materialize collections
- Add, Delete, Modify CORS Rules
- New 'CORS' tab added to settings modal.
- Cors Settings model fragments added

![](http://g.recordit.co/yKLVFvaCnI.gif)