### PR TITLE
Include EGR in Copied Node Modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
         copy: {
             app: {
                 expand: true,
-                src: ['electron.js', 'package.json', 'dist/**', 'node_modules/azure-storage/**', 'node_modules/fs-extra/**'],
+                src: ['electron.js', 'package.json', 'dist/**', 'node_modules/azure-storage/**', 'node_modules/fs-extra/**', 'node_modules/electron-gh-releases/**'],
                 dest: 'electronbuildcache/'
             },
             version_file: {


### PR DESCRIPTION
- Electron-Gh-Releases is being called in the `main` of Electron during
the startup routine, checking for app updates (updating the app if a
new version is available). This change includes it in Grunt’s copy
pipeline.